### PR TITLE
Refactor:Replace put/delete with mutate in kv service

### DIFF
--- a/src/saltfish/service/kv_service.h
+++ b/src/saltfish/service/kv_service.h
@@ -19,7 +19,7 @@
 
 namespace saltfish {
 namespace service {
-class KVServiceImpl : public proto::SaltFishKVService {
+class KVServiceImpl : public proto::KVService {
  public:
   void Get(::google::protobuf::RpcController *controller,
            const ::saltfish::service::proto::PutRequest *request,

--- a/src/saltfish/service/kv_service.proto
+++ b/src/saltfish/service/kv_service.proto
@@ -30,10 +30,20 @@ message GetResponse {
     optional bytes value = 2;
 };
 
+message Mutate {
+    enum Type {
+        PUT = 0;
+        DEL = 1;
+        NONE = 2;
+    }
+    required Type type = 1;
+    required bytes key = 2;
+    optional bytes value = 3;
+}
+
 message PutRequest {
     required RequestHeader header = 1;
-    required bytes key = 2;
-    required bytes value = 3;
+    required Mutate put = 2;
 };
 
 message PutResponse {
@@ -42,14 +52,14 @@ message PutResponse {
 
 message DeleteRequest {
     required RequestHeader header = 1;
-    required bytes key = 2;
+    required Mutate del = 2;
 };
 
 message DeleteResponse {
     required ResponseHeader header = 1;
 }
 
-service SaltFishKVService {
+service KVService {
     rpc Get(PutRequest) returns (GetResponse);
     rpc Put(PutRequest) returns (PutResponse);
     rpc Delete(PutRequest) returns (DeleteResponse);


### PR DESCRIPTION
将put和del请求合并成一个mutate op，这样我们在底层的engine接口只需要提供一个mutate接口。为什么不在rpc层直接用一个mutate呢？是这样考虑的，单独提供del/put接口更方便利用brpc的concurreny限制以及对不同请求的qos实现。